### PR TITLE
feat(category): 카테고리 API 연동 및 카테고리별 상품 목록 페이지 추가

### DIFF
--- a/src/app/(main)/category/[id]/goods/page.tsx
+++ b/src/app/(main)/category/[id]/goods/page.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import { useState } from "react";
+import { ProductCard } from "@/components/domain/ProductCard";
+import { Button } from "@/components/ui/Button";
+import { Spinner } from "@/components/ui/Spinner";
+import { useCategoryTree, useCategoryProducts } from "@/features/category/hooks";
+import { useAuthStore } from "@/features/auth/store";
+import { useAddLike, useRemoveLike, useMyLikes } from "@/features/likes/hooks";
+import type { ProductSort } from "@/features/product/types";
+import type { CategoryItem } from "@/features/category/types";
+
+const SORT_OPTIONS: { value: ProductSort; label: string }[] = [
+  { value: "LATEST_DESC", label: "최신순" },
+  { value: "LIKES_DESC", label: "인기순" },
+  { value: "PRICE_ASC", label: "낮은 가격순" },
+  { value: "PRICE_DESC", label: "높은 가격순" },
+];
+
+const PAGE_SIZE = 20;
+
+function findCategory(categories: CategoryItem[], id: number): CategoryItem | null {
+  for (const cat of categories) {
+    if (cat.id === id) return cat;
+    const found = findCategory(cat.children, id);
+    if (found) return found;
+  }
+  return null;
+}
+
+function findParentCategory(categories: CategoryItem[], id: number): CategoryItem | null {
+  for (const cat of categories) {
+    if (cat.children.some((child) => child.id === id)) return cat;
+    const found = findParentCategory(cat.children, id);
+    if (found) return found;
+  }
+  return null;
+}
+
+export default function CategoryGoodsPage() {
+  const params = useParams();
+  const router = useRouter();
+  const categoryId = params?.id ? Number(params.id) : null;
+
+  const [page, setPage] = useState(0);
+  const [sort, setSort] = useState<ProductSort>("LATEST_DESC");
+  const userId = useAuthStore((s) => s.userId);
+
+  const { data: categoryData, isLoading: categoryLoading } = useCategoryTree();
+  const categories = categoryData?.categories ?? [];
+
+  const category = categoryId != null ? findCategory(categories, categoryId) : null;
+  const parentCategory = categoryId != null ? findParentCategory(categories, categoryId) : null;
+
+  // 최상위 카테고리인 경우 자기 자신이 parent
+  const isTopLevel = parentCategory === null && category != null;
+  const siblingCategories = isTopLevel
+    ? categories
+    : (parentCategory?.children ?? []);
+
+  const { data: productData, isLoading: productLoading, isError, error } = useCategoryProducts({
+    categoryId,
+    page,
+    size: PAGE_SIZE,
+    productSort: sort,
+  });
+
+  const { data: likesData } = useMyLikes();
+  const likedIds = new Set(
+    likesData?.likedProducts?.map((p) => p.productId) ?? []
+  );
+  const addLike = useAddLike();
+  const removeLike = useRemoveLike();
+
+  if (categoryId == null) {
+    return (
+      <div className="mx-auto max-w-7xl px-4 py-16 text-center sm:px-6">
+        <p className="text-body text-red-600">잘못된 카테고리입니다.</p>
+        <Link
+          href="/"
+          className="mt-4 inline-block text-body text-brand-gray underline hover:text-brand-black"
+        >
+          홈으로 돌아가기
+        </Link>
+      </div>
+    );
+  }
+
+  if (categoryLoading) {
+    return (
+      <div className="flex min-h-[50vh] items-center justify-center">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  const products = productData?.items ?? [];
+  const totalPage = productData?.totalPage ?? 1;
+  const totalItems = productData?.totalItems ?? 0;
+
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6">
+      {/* 브레드크럼 */}
+      <nav className="flex items-center gap-1.5 text-caption text-brand-gray">
+        <Link href="/" className="hover:text-brand-black">
+          홈
+        </Link>
+        <span>/</span>
+        {parentCategory && !isTopLevel && (
+          <>
+            <Link
+              href={`/category/${parentCategory.id}/goods`}
+              className="hover:text-brand-black"
+            >
+              {parentCategory.name}
+            </Link>
+            <span>/</span>
+          </>
+        )}
+        <span className="text-brand-black">{category?.name ?? "카테고리"}</span>
+      </nav>
+
+      {/* 카테고리 타이틀 */}
+      <h1 className="mt-4 text-display font-bold text-brand-black">
+        {category?.name ?? "카테고리"}
+      </h1>
+
+      {/* 하위/형제 카테고리 탭 */}
+      {siblingCategories.length > 1 && (
+        <div className="mt-5 flex flex-wrap gap-2">
+          {/* 전체 보기 (부모 카테고리) */}
+          {parentCategory && !isTopLevel && (
+            <button
+              type="button"
+              onClick={() => {
+                router.push(`/category/${parentCategory.id}/goods`);
+              }}
+              className={`rounded-full border px-4 py-2 text-body transition-colors ${
+                categoryId === parentCategory.id
+                  ? "border-brand-black bg-brand-black text-brand-white"
+                  : "border-brand-border bg-brand-white text-brand-black hover:bg-brand-bg"
+              }`}
+            >
+              전체
+            </button>
+          )}
+          {siblingCategories.map((cat) => (
+            <button
+              key={cat.id}
+              type="button"
+              onClick={() => {
+                setPage(0);
+                router.push(`/category/${cat.id}/goods`);
+              }}
+              className={`rounded-full border px-4 py-2 text-body transition-colors ${
+                cat.id === categoryId
+                  ? "border-brand-black bg-brand-black text-brand-white"
+                  : "border-brand-border bg-brand-white text-brand-black hover:bg-brand-bg"
+              }`}
+            >
+              {cat.name}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* 하위 카테고리 칩 (선택된 카테고리가 자식을 가진 경우) */}
+      {category && category.children.length > 0 && (
+        <div className="mt-4 flex flex-wrap gap-2">
+          {category.children.map((child) => (
+            <Link
+              key={child.id}
+              href={`/category/${child.id}/goods`}
+              className="rounded-full border border-brand-border bg-brand-white px-3.5 py-1.5 text-caption text-brand-black transition-colors hover:bg-brand-bg"
+            >
+              {child.name}
+            </Link>
+          ))}
+        </div>
+      )}
+
+      {/* 상품 수 + 정렬 */}
+      <div className="mt-6 flex items-center justify-between border-b border-brand-border pb-4">
+        <p className="text-body text-brand-gray">
+          상품 <span className="font-semibold text-brand-black">{totalItems.toLocaleString()}</span>개
+        </p>
+        <select
+          value={sort}
+          onChange={(e) => {
+            setSort(e.target.value as ProductSort);
+            setPage(0);
+          }}
+          className="rounded-lg border border-brand-border bg-brand-white px-4 py-2.5 text-body text-brand-black focus:outline-none focus:ring-2 focus:ring-brand-black"
+        >
+          {SORT_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* 상품 그리드 */}
+      {productLoading ? (
+        <div className="flex justify-center py-16">
+          <Spinner size="lg" />
+        </div>
+      ) : isError ? (
+        <div className="py-16 text-center">
+          <p className="text-body text-red-600">
+            {error?.message ?? "상품을 불러올 수 없습니다."}
+          </p>
+        </div>
+      ) : products.length === 0 ? (
+        <div className="py-16 text-center">
+          <p className="text-body text-brand-gray">해당 카테고리에 상품이 없습니다.</p>
+        </div>
+      ) : (
+        <>
+          <div className="mt-6 grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:gap-6">
+            {products.map((product) => (
+              <ProductCard
+                key={product.productId}
+                product={product}
+                liked={likedIds.has(product.productId)}
+                onLike={
+                  userId ? () => addLike.mutate(product.productId) : undefined
+                }
+                onUnlike={
+                  userId ? () => removeLike.mutate(product.productId) : undefined
+                }
+              />
+            ))}
+          </div>
+
+          {/* 페이지네이션 */}
+          {totalPage > 1 && (
+            <div className="mt-12 flex items-center justify-center gap-4">
+              <Button
+                variant="secondary"
+                disabled={page === 0}
+                onClick={() => setPage((p) => Math.max(0, p - 1))}
+              >
+                이전
+              </Button>
+              <span className="text-body text-brand-gray">
+                {page + 1} / {totalPage}
+              </span>
+              <Button
+                variant="secondary"
+                disabled={page >= totalPage - 1}
+                onClick={() => setPage((p) => p + 1)}
+              >
+                다음
+              </Button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/GlobalMenuModal.tsx
+++ b/src/components/layout/GlobalMenuModal.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
 import {
   brandGroups,
-  menuCategories,
   popularBrands,
   type BrandGroup,
   type MenuTab,
 } from "@/features/brand/mockMenuData";
+import { useCategoryTree } from "@/features/category/hooks";
+import { Spinner } from "@/components/ui/Spinner";
 
 interface GlobalMenuModalProps {
   isOpen: boolean;
@@ -15,12 +17,21 @@ interface GlobalMenuModalProps {
 }
 
 export function GlobalMenuModal({ isOpen, onClose }: GlobalMenuModalProps) {
+  const router = useRouter();
   const [selectedTab, setSelectedTab] = useState<MenuTab>("category");
-  const [selectedCategoryId, setSelectedCategoryId] = useState<string>(
-    menuCategories[0]?.id ?? ""
-  );
+  const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(null);
   const [selectedBrandGroup, setSelectedBrandGroup] = useState<BrandGroup>("의류");
   const [searchTerm, setSearchTerm] = useState("");
+
+  const { data: categoryData, isLoading: categoryLoading } = useCategoryTree();
+  const categories = categoryData?.categories ?? [];
+
+  // 카테고리 로드 후 첫 번째 항목 자동 선택
+  useEffect(() => {
+    if (selectedCategoryId === null && categories.length > 0) {
+      setSelectedCategoryId(categories[0].id);
+    }
+  }, [categories, selectedCategoryId]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -48,8 +59,8 @@ export function GlobalMenuModal({ isOpen, onClose }: GlobalMenuModalProps) {
   }, [searchTerm, selectedBrandGroup]);
 
   const selectedCategory = useMemo(
-    () => menuCategories.find((category) => category.id === selectedCategoryId),
-    [selectedCategoryId]
+    () => categories.find((category) => category.id === selectedCategoryId),
+    [categories, selectedCategoryId]
   );
 
   if (!isOpen) return null;
@@ -97,43 +108,76 @@ export function GlobalMenuModal({ isOpen, onClose }: GlobalMenuModalProps) {
 
         <div className="flex min-h-0 flex-1">
           {selectedTab === "category" ? (
-            <>
-              <aside className="w-52 shrink-0 border-r border-brand-border bg-[#fafafa] px-2 py-3">
-                {menuCategories.map((category) => (
-                  <button
-                    key={category.id}
-                    type="button"
-                    onClick={() => setSelectedCategoryId(category.id)}
-                    className={`flex w-full items-center rounded-lg px-4 py-3 text-left text-body transition-colors ${
-                      selectedCategoryId === category.id
-                        ? "bg-brand-black text-brand-white"
-                        : "text-brand-black hover:bg-brand-bg"
-                    }`}
-                  >
-                    {category.name}
-                  </button>
-                ))}
-              </aside>
-              <section className="flex-1 overflow-y-auto px-6 py-6 sm:px-8">
-                <h3 className="text-display font-bold text-brand-black">
-                  {selectedCategory?.name ?? "카테고리"}
-                </h3>
-                <p className="mt-2 text-body text-brand-gray">
-                  무신사 스타일로 자주 찾는 카테고리를 빠르게 탐색할 수 있어요.
-                </p>
-                <div className="mt-6 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
-                  {menuCategories.map((category) => (
+            categoryLoading ? (
+              <div className="flex flex-1 items-center justify-center">
+                <Spinner size="lg" />
+              </div>
+            ) : categories.length === 0 ? (
+              <div className="flex flex-1 items-center justify-center">
+                <p className="text-body text-brand-gray">카테고리가 없습니다.</p>
+              </div>
+            ) : (
+              <>
+                <aside className="w-52 shrink-0 overflow-y-auto border-r border-brand-border bg-[#fafafa] px-2 py-3">
+                  {categories.map((category) => (
                     <button
-                      key={`tile-${category.id}`}
+                      key={category.id}
                       type="button"
-                      className="rounded-lg border border-brand-border bg-brand-white px-4 py-4 text-left text-body font-medium text-brand-black transition-colors hover:bg-brand-bg"
+                      onClick={() => setSelectedCategoryId(category.id)}
+                      className={`flex w-full items-center rounded-lg px-4 py-3 text-left text-body transition-colors ${
+                        selectedCategoryId === category.id
+                          ? "bg-brand-black text-brand-white"
+                          : "text-brand-black hover:bg-brand-bg"
+                      }`}
                     >
                       {category.name}
                     </button>
                   ))}
-                </div>
-              </section>
-            </>
+                </aside>
+                <section className="flex-1 overflow-y-auto px-6 py-6 sm:px-8">
+                  <h3 className="text-display font-bold text-brand-black">
+                    {selectedCategory?.name ?? "카테고리"}
+                  </h3>
+                  <p className="mt-2 text-body text-brand-gray">
+                    카테고리를 선택하여 상품을 탐색할 수 있어요.
+                  </p>
+                  <div className="mt-6 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+                    {/* 전체 보기 */}
+                    {selectedCategory && (
+                      <button
+                        key={`all-${selectedCategory.id}`}
+                        type="button"
+                        onClick={() => {
+                          router.push(`/category/${selectedCategory.id}/goods`);
+                          onClose();
+                        }}
+                        className="rounded-lg border border-brand-black bg-brand-black px-4 py-4 text-left text-body font-medium text-brand-white transition-colors hover:opacity-90"
+                      >
+                        전체 보기
+                      </button>
+                    )}
+                    {(selectedCategory?.children ?? []).map((child) => (
+                      <button
+                        key={child.id}
+                        type="button"
+                        onClick={() => {
+                          router.push(`/category/${child.id}/goods`);
+                          onClose();
+                        }}
+                        className="rounded-lg border border-brand-border bg-brand-white px-4 py-4 text-left text-body font-medium text-brand-black transition-colors hover:bg-brand-bg"
+                      >
+                        {child.name}
+                      </button>
+                    ))}
+                    {(selectedCategory?.children ?? []).length === 0 && !selectedCategory && (
+                      <p className="col-span-full text-body text-brand-gray">
+                        하위 카테고리가 없습니다.
+                      </p>
+                    )}
+                  </div>
+                </section>
+              </>
+            )
           ) : (
             <>
               <aside className="w-52 shrink-0 border-r border-brand-border bg-[#fafafa] px-2 py-3">

--- a/src/features/brand/mockMenuData.ts
+++ b/src/features/brand/mockMenuData.ts
@@ -2,31 +2,11 @@ export type MenuTab = "category" | "brand";
 
 export type BrandGroup = "의류" | "뷰티" | "신발" | "스니커즈";
 
-export interface CategoryItem {
-  id: string;
-  name: string;
-}
-
 export interface BrandItem {
   id: number;
   name: string;
   group: BrandGroup;
 }
-
-export const menuCategories: CategoryItem[] = [
-  { id: "beauty", name: "뷰티" },
-  { id: "shoes", name: "신발" },
-  { id: "tops", name: "상의" },
-  { id: "outer", name: "아우터" },
-  { id: "pants", name: "바지" },
-  { id: "dress", name: "원피스" },
-  { id: "skirt", name: "스커트" },
-  { id: "bag", name: "가방" },
-  { id: "accessory", name: "소품" },
-  { id: "sports", name: "스포츠" },
-  { id: "underwear", name: "언더웨어" },
-  { id: "kids", name: "키즈" },
-];
 
 export const brandGroups: BrandGroup[] = ["의류", "뷰티", "신발", "스니커즈"];
 

--- a/src/features/category/api.ts
+++ b/src/features/category/api.ts
@@ -1,0 +1,20 @@
+import { client } from "@/lib/api/client";
+import type { ProductSummaryResponse } from "@/features/product/types";
+import type { CategoryTreeResponse, CategoryProductsParams } from "./types";
+
+export async function getCategories(): Promise<CategoryTreeResponse> {
+  return client.get<CategoryTreeResponse>("/categories");
+}
+
+export async function getCategoryProducts(
+  params: CategoryProductsParams
+): Promise<ProductSummaryResponse> {
+  const search = new URLSearchParams({
+    page: String(params.page),
+    size: String(params.size),
+    productSort: params.productSort,
+  });
+  return client.get<ProductSummaryResponse>(
+    `/categories/${params.categoryId}/products?${search}`
+  );
+}

--- a/src/features/category/hooks.ts
+++ b/src/features/category/hooks.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { getCategories, getCategoryProducts } from "./api";
+import type { ProductSort } from "@/features/product/types";
+
+const categoryKey = ["category"] as const;
+
+export function useCategoryTree() {
+  return useQuery({
+    queryKey: [...categoryKey, "tree"],
+    queryFn: getCategories,
+  });
+}
+
+export function useCategoryProducts(params: {
+  categoryId: number | null;
+  page: number;
+  size: number;
+  productSort: ProductSort;
+}) {
+  return useQuery({
+    queryKey: [...categoryKey, params.categoryId, "products", {
+      page: params.page,
+      size: params.size,
+      productSort: params.productSort,
+    }],
+    queryFn: () =>
+      getCategoryProducts({
+        categoryId: params.categoryId!,
+        page: params.page,
+        size: params.size,
+        productSort: params.productSort,
+      }),
+    enabled: params.categoryId != null,
+  });
+}

--- a/src/features/category/types.ts
+++ b/src/features/category/types.ts
@@ -1,0 +1,18 @@
+import type { ProductSort } from "@/features/product/types";
+
+export interface CategoryItem {
+  id: number;
+  name: string;
+  children: CategoryItem[];
+}
+
+export interface CategoryTreeResponse {
+  categories: CategoryItem[];
+}
+
+export interface CategoryProductsParams {
+  categoryId: number;
+  page: number;
+  size: number;
+  productSort: ProductSort;
+}


### PR DESCRIPTION
## Summary
- `features/category` 모듈 생성 (api, hooks, types) — 카테고리 트리 조회 및 카테고리별 상품 조회 API 연동
- GlobalMenuModal 하드코딩 카테고리를 백엔드 API 호출로 교체, 카테고리 클릭 시 상품 페이지로 이동
- 카테고리 상품 페이지 `/category/{id}/goods` 추가 (무신사 URL 패턴 참고) — 브레드크럼, 형제/하위 카테고리 탭, 정렬, 페이지네이션

## Test plan
- [x] GlobalMenuModal > 카테고리 탭에서 API 데이터가 렌더링되는지 확인
- [x] 하위 카테고리 / 전체 보기 클릭 시 `/category/{id}/goods`로 이동하는지 확인
- [x] 카테고리 상품 페이지에서 정렬 변경, 페이지네이션이 동작하는지 확인
- [x] 브레드크럼으로 상위 카테고리 이동이 되는지 확인

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)